### PR TITLE
Feature/mdns sd improvement

### DIFF
--- a/src/main/java/com/mlaf/hu/proxy/JMDNSManager.java
+++ b/src/main/java/com/mlaf/hu/proxy/JMDNSManager.java
@@ -102,13 +102,13 @@ public class JMDNSManager {
         }
         logger.log(Level.INFO, "JMDNS created for IP {0}", inetAddress.getHostAddress());
         
-        
-        try{
-            String refRate =  Configuration.getInstance().getProperty(refreshPropertyName);
+        String refRate =  Configuration.getInstance().getProperty(refreshPropertyName);
+        try{  
             refreshRate = refRate != null ? Integer.parseInt(refRate) * 1000 : 60000;
             startRefreshTask();
         }catch(NumberFormatException e){
-            logger.log(Level.WARNING, "JMDNSManager could not start refresh task. Invalid value for: {0} in configuration.", refreshPropertyName);
+            logger.log(Level.WARNING, () -> 
+                    String.format("JMDNSManager could not start refresh task. Invalid value [%s] for [%s] in configuration: %s", refRate, refreshPropertyName, e.toString()));
         }
         
     }

--- a/src/main/java/com/mlaf/hu/proxy/JMDNSRefreshTask.java
+++ b/src/main/java/com/mlaf/hu/proxy/JMDNSRefreshTask.java
@@ -1,0 +1,24 @@
+package com.mlaf.hu.proxy;
+
+import java.util.TimerTask;
+import javax.jmdns.JmDNS;
+import javax.jmdns.impl.JmDNSImpl;
+
+/**
+ *
+ * @author Rogier
+ */
+public class JMDNSRefreshTask extends TimerTask{
+    private final JmDNS jmdns;
+    private final String mdnsType;
+    
+    public JMDNSRefreshTask(JmDNS jmdns, String mdnsType){
+        this.jmdns = jmdns;
+        this.mdnsType = mdnsType;
+    }
+    
+    @Override
+    public void run(){
+        ((JmDNSImpl) jmdns).startServiceResolver(mdnsType);
+    }
+}

--- a/src/main/java/com/mlaf/hu/proxy/TcpMtpAgent.java
+++ b/src/main/java/com/mlaf/hu/proxy/TcpMtpAgent.java
@@ -50,14 +50,7 @@ public class TcpMtpAgent extends Agent {
                 
                 AMSService.register(TcpMtpAgent.this, amsad);   
                 
-                ACLMessage request;
-                try {
-                    request = createInstructionRequest(aid);
-                    send(request);	
-                } catch (ServiceDiscoveryNotFoundException ex) {
-                    Logger.getLogger(TcpMtpAgent.class.getName()).log(Level.WARNING, "DecisionAgent not found, no instructionset requested: {0}", ex);
-                }
- 	
+                handshakeExternalAgent(aid);
             } catch (FIPAException ex) {
                 logger.log(Level.WARNING, "Could not register " + agentName, ex.getACLMessage());
             }
@@ -131,23 +124,17 @@ public class TcpMtpAgent extends Agent {
         }
 
         logger.log(Level.INFO, "TcpMtpAgent {0}: starting", getLocalName());
-        this.addBehaviour(new AgentJMDNSRegisterBehaviour(jmdnsManager));
-        this.addBehaviour(new CyclicBehaviour(){
-                @Override
-                public void action(){ 
-                    ACLMessage message = receive(MessageTemplate.MatchPerformative(ACLMessage.REQUEST));
-                    
-                    if(message == null || !message.getContent().equals("restart-jmdns"))
-                        return;
-                    
-                    try {
-                        jmdnsManager.restart();
-                    } catch (IOException ex) {
-                        Logger.getLogger(TcpMtpAgent.class.getName()).log(Level.SEVERE, null, ex);
-                    }
-               
-                }
-        });   
+        this.addBehaviour(new AgentJMDNSRegisterBehaviour(jmdnsManager));   
+    }
+    
+    protected void handshakeExternalAgent(AID aid){
+        ACLMessage request;
+        try {
+            request = createInstructionRequest(aid);
+            send(request);	
+        } catch (ServiceDiscoveryNotFoundException ex) {
+            Logger.getLogger(TcpMtpAgent.class.getName()).log(Level.WARNING, "DecisionAgent not found, no instructionset requested: {0}", ex);
+        }
     }
     
     protected ACLMessage createInstructionRequest(AID receiver) throws ServiceDiscoveryNotFoundException{

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,5 +1,6 @@
-# proxy configuration
+# proxy configuration (refresh_rate value = time in seconds. Default = 60)
 proxy.port=6789
+proxy.mdns.refresh_rate=10
 
 # smtp mail server configuration
 mail.host=smtp.gmail.com


### PR DESCRIPTION
Geeft via config.properties de mogelijkheid om de mDNS refresh rate in te stellen. mDNS service discovery stopt niet meer na de eerste minuut van JADE opstarten. In andere woorden, SD werkt nu eindelijk zoals verwacht: JADE kan blijven draaien en wanneer een ESP aangesloten wordt, wordt deze na de volgende refresh gevonden.